### PR TITLE
Explicitly disable zstd support

### DIFF
--- a/build-qemu.sh
+++ b/build-qemu.sh
@@ -64,7 +64,7 @@ function build_qemu() {
     pushd "${source_dir}"
 
     ./configure --disable-bsd-user --disable-guest-agent --disable-curses --disable-libssh --disable-gnutls --enable-slirp=system \
-        --enable-vde --enable-virtfs --disable-sdl --enable-cocoa --disable-curses --disable-gtk --prefix="${PREFIX}" \
+        --enable-vde --enable-virtfs --disable-sdl --enable-cocoa --disable-curses --disable-gtk --disable-zstd --prefix="${PREFIX}" \
         --target-list="${qemu_target}"
 
     make V=1 install


### PR DESCRIPTION
when zstd lib is available on the build machine it is automatically
enabled which we don't want

Signed-off-by: Anjan Nath <kaludios@gmail.com>