### PR TITLE
Add support for earlier macOS releases

### DIFF
--- a/build-qemu.sh
+++ b/build-qemu.sh
@@ -55,10 +55,12 @@ function build_qemu() {
          "x86_64")
              qemu_target="x86_64-softmmu"
              macos_version_min_flags="-mmacosx-version-min=10.15"
+             export MACOSX_DEPLOYMENT_TARGET=10.15
              ;;
          "arm64")
              qemu_target="aarch64-softmmu"
              macos_version_min_flags="-mmacosx-version-min=11.0"
+             export MACOSX_DEPLOYMENT_TARGET=11.0
              ;;
          *)
              echo "Unknown arch, exiting"

--- a/build-qemu.sh
+++ b/build-qemu.sh
@@ -50,12 +50,15 @@ function build_qemu() {
     source_dir=$(download_and_extract "${QEMU_SOURCE_URL}")
  
     local qemu_target
+    local macos_version_min_flags
     case "$(uname -m)" in
          "x86_64")
              qemu_target="x86_64-softmmu"
+             macos_version_min_flags="-mmacosx-version-min=10.15"
              ;;
          "arm64")
              qemu_target="aarch64-softmmu"
+             macos_version_min_flags="-mmacosx-version-min=11.0"
              ;;
          *)
              echo "Unknown arch, exiting"
@@ -65,6 +68,8 @@ function build_qemu() {
 
     pushd "${source_dir}"
     export PATH=${PREFIX}/bin:${PATH}
+    export CPPFLAGS="${CPPFLAGS} ${macos_version_min_flags}"
+    export CFLAGS="${macos_version_min_flags}"
     ./configure --disable-bsd-user --disable-guest-agent --disable-curses --disable-libssh --disable-gnutls --enable-slirp=system \
         --enable-vde --enable-virtfs --disable-sdl --enable-cocoa --disable-curses --disable-gtk --disable-zstd --enable-gcrypt \
         --prefix="${PREFIX}" --target-list="${qemu_target}"

--- a/build.sh
+++ b/build.sh
@@ -46,9 +46,11 @@ NCORES=$(sysctl -n hw.ncpu)
 case "$(uname -m)" in
     "x86_64")
         CPU="amd64"
+        macos_version_min_flags="-mmacosx-version-min=10.15"
         ;;
     "arm64")
         CPU="aarch64"
+        macos_version_min_flags="-mmacosx-version-min=11.0"
         ;;
     *)
         echo "Unknown arch, exiting"
@@ -58,6 +60,9 @@ esac
 
 KERNEL_VERSION=$(uname -r)
 KERNEL_BUILD_FLAG="${CPU}-apple-darwin${KERNEL_VERSION%%.*}" # aarch64-apple-darwin21
+
+export CFLAGS="${macos_version_min_flags}"
+export CPPFLAGS="${macos_version_min_flags}"
 
 # the following are depenedencies of glib
 function build_lib_gettext() {

--- a/build.sh
+++ b/build.sh
@@ -47,10 +47,12 @@ case "$(uname -m)" in
     "x86_64")
         CPU="amd64"
         macos_version_min_flags="-mmacosx-version-min=10.15"
+        export MACOSX_DEPLOYMENT_TARGET=10.15
         ;;
     "arm64")
         CPU="aarch64"
         macos_version_min_flags="-mmacosx-version-min=11.0"
+        export MACOSX_DEPLOYMENT_TARGET=11.0
         ;;
     *)
         echo "Unknown arch, exiting"


### PR DESCRIPTION
Using macos_version_min_flags the lowest supported
version can be configured in the build scripts.
With his commit this is 10.15 for amd64 and 11.0 for arm64.

This has been tested w/ a built on macOS Monterey (12.6) which
runs on 12.6 itself as well as on Catalina (10.15).
